### PR TITLE
Add support for a custom Fly config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,10 @@ If you have an existing `fly.toml` in your repo, this action will copy it with a
 ## Inputs
 
 | name       | description                                                                                                                                                                                              |
-| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `name`     | The name of the Fly app. Alternatively, set the env `FLY_APP`. For safety, must include the PR number. Example: `myapp-pr-${{ github.event.number }}`. Defaults to `pr-{number}-{repo_org}-{repo_name}`. |
+| `image`    | Optional pre-existing Docker image to use                                                                                                                                                                |
+| `config`   | Optional path to a custom Fly toml config. Config path should be relative to `path` parameter, if specified.                                                                                             |
 | `region`   | Which Fly region to run the app in. Alternatively, set the env `FLY_REGION`. Defaults to `iad`.                                                                                                          |
 | `org`      | Which Fly organization to launch the app under. Alternatively, set the env `FLY_ORG`. Defaults to `personal`.                                                                                            |
 | `path`     | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: Fly app name
   image:
     description: Optional pre-existing Docker image to use
+  config:
+    description: Optional path to a custom Fly toml config. Config path should be relative to `path` parameter, if specified.
   region:
     description: Region to launch the app in (alternatively, set the env FLY_REGION)
   org:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,7 @@ app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
+config="$INPUT_CONFIG"
 
 if ! echo "$app" | grep "$PR_NUMBER"; then
   echo "For safety, this action requires the app's name to contain the PR number."
@@ -38,7 +39,7 @@ fi
 if ! flyctl status --app "$app"; then
   flyctl launch --now --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
 elif [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --region "$region" --image "$image" --region "$region" --strategy immediate
+  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --region "$region" --strategy immediate
 fi
 
 # Attach postgres cluster to the app if specified.


### PR DESCRIPTION
This change supports adding an optional Fly toml config file path when
deploying the application.

If `name` is specified in the action config, it will override any `name`
attribute in the config file.

The config file path should be relative to the `path` parameter, if one
is specified.