### PR TITLE
Attach postgres before launch to enable DB operations during startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,14 +36,16 @@ fi
 
 # Deploy the Fly app, creating it first if needed.
 if ! flyctl status --app "$app"; then
-  flyctl launch --now --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
-elif [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --app "$app" --region "$region" --image "$image" --region "$region" --strategy immediate
+  flyctl create --name "$app" --org "$org"
 fi
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then
-  flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
+  flyctl postgres attach --app "$app" --postgres-app "$INPUT_POSTGRES" || true
+fi
+
+if [ "$INPUT_UPDATE" != "false" ]; then
+  flyctl deploy --app "$app" --region "$region" --strategy immediate --image "$image"
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
`flyctl launch` will create apps if they don't exist *and* launch them. This causes issues with apps that perform database operations on startup (e.g. migrations), since the Postgres cluster can't be attached before the app is created, but the DB operations can't run during launch without the cluster attached.

This diff replaces `flyctl launch` with `flyctl create`. This has the effect of only *creating* the app, which can then be attached to a Postgres app (if one is provided via `$INPUT_POSTGRES`). Afterwards, unless `$INPUT_UPDATE` is set to false, the app is deployed.

I tested as follows:
1. Verify that the base action fails during launch if the deploy involves a database operation (because `$DATABASE_URL` is not set).
2. Apply the change.
3. Verify that the deploy successfully runs the database operation and ultimately succeeds.