### PR TITLE
refactor: consistent cli name use

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ if [ -n "$INPUT_POSTGRES" ]; then
 fi
 
 # Make some info available to the GitHub workflow.
-fly status --app "$app" --json >status.json
+flyctl status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
 appid=$(jq -r .ID status.json)
 echo "::set-output name=hostname::$hostname"


### PR DESCRIPTION
When using `superfly/flyctl-actions/setup-flyctl@master` then its also a fix as that action is not setting up `fly`:

<img width="856" alt="CleanShot 2022-08-05 at 11 28 38@2x" src="https://user-images.githubusercontent.com/284476/183110471-c0f1179f-0afa-4d56-89a9-d9025a07171d.png">

Of course the code changed here is internal but I've been copying it out for some custom stuff and it tripped me up.

The motivation of consistency here is enough I think.