### PR TITLE
Add support for custom app name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`
+    description: Secrets to be set on the app. Separate multiple secrets with a space.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,7 +18,7 @@ REPO_NAME=$(jq -r .event.base.repo.name /github/workflow/event.json)
 EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
-app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"
+app="${INPUT_NAME:-${FLY_APP:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}}"
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"


### PR DESCRIPTION
This change supports custom app name by setting env `FLY_APP`.
Using `FLY_APP` env is in the readme but is not implemented currently.

I'm not sure why this feature was not implemented, this also could be a workaround fix for https://github.com/superfly/fly-pr-review-apps/issues/10 by setting custom deployment name.