### PR TITLE
Remove expression from secrets description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`
+    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=FOO SECOND_SECRET=BAR``


### PR DESCRIPTION
The secrets description contains the `${{ secrets.x }}` syntax, which GitHub Actions tries to evaluate when pulling the action, breaking every workflow that uses this action as `secrets` is not available.