### PR TITLE
Various fixes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`
+    description: "Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`"

--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,10 @@ inputs:
     default: true
   secrets:
     description: Secrets to be set on the app. Separate multiple secrets with a space
+  vm:
+    description: Set app VM to a named size, eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x etc. (defaults to shared-cpu-1x)
+  memory:
+    description: Set app VM memory (defaults to 256 megabytes)
+  count:
+    description: Set app VM count to the given value (defaults to 1)
+

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: "Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`"
+    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=\\${{ secrets.FIRST_SECRET }} SECOND_SECRET=\\${{ secrets.SECOND_SECRET }}`

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=\\${{ secrets.FIRST_SECRET }} SECOND_SECRET=\\${{ secrets.SECOND_SECRET }}`
+    description: Secrets to be set on the app. Separate multiple secrets with a space

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,3 @@ inputs:
     default: true
   secrets:
     description: Secrets to be set on the app. Separate multiple secrets with a space
-  build_secret:
-    description: Additional build secret for Fly deploy command. See - https://fly.io/docs/reference/build-secrets/

--- a/action.yml
+++ b/action.yml
@@ -27,3 +27,5 @@ inputs:
     default: true
   secrets:
     description: Secrets to be set on the app. Separate multiple secrets with a space
+  extra-deploy-args:
+    description: Additional args for Fly deploy command

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     default: true
   secrets:
     description: Secrets to be set on the app. Separate multiple secrets with a space
-  extra_deploy_args:
-    description: Additional args for Fly deploy command
+  build_secret:
+    description: Additional build secret for Fly deploy command. See - https://fly.io/docs/reference/build-secrets/

--- a/action.yml
+++ b/action.yml
@@ -27,5 +27,5 @@ inputs:
     default: true
   secrets:
     description: Secrets to be set on the app. Separate multiple secrets with a space
-  extra-deploy-args:
+  extra_deploy_args:
     description: Additional args for Fly deploy command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,6 @@ fi
 fly status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
 appid=$(jq -r .ID status.json)
-echo "::set-output name=hostname::$hostname"
-echo "::set-output name=url::https://$hostname"
-echo "::set-output name=id::$appid"
+echo "hostname=$hostname" >> $GITHUB_OUTPUT
+echo "url=https://$hostname" >> $GITHUB_OUTPUT
+echo "id=$appid" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,7 +17,7 @@ REPO_NAME=$(echo $GITHUB_REPOSITORY | tr "/" "-")
 EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
 # Default the Fly app name to pr-{number}-{repo_name}
-app="${INPUT_NAME:-pr-$PR_NUMBER--$REPO_NAME}"
+app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_NAME}"
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,8 @@ if [ -n "$INPUT_SECRETS" ]; then
   echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
 
+printenv
+
 echo "Contents of config $config file: " && cat "$config"
 flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate "$INPUT_EXTRA_DEPLOY_ARGS"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,8 +46,6 @@ if [ -n "$INPUT_SECRETS" ]; then
   echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
 
-printenv
-
 echo "Contents of config $config file: " && cat "$config"
 flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate "$INPUT_EXTRA_DEPLOY_ARGS"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,20 +7,17 @@ if [ -n "$INPUT_PATH" ]; then
   cd "$INPUT_PATH" || exit
 fi
 
-echo "Got workflow event: $(cat /github/workflow/event.json)"
-
 PR_NUMBER=$(jq -r .number /github/workflow/event.json)
 if [ -z "$PR_NUMBER" ]; then
   echo "This action only supports pull_request actions."
   exit 1
 fi
 
-REPO_OWNER=$GITHUB_REPOSITORY_OWNER
-REPO_NAME=$GITHUB_REPOSITORY
+REPO_NAME=$(echo $GITHUB_REPOSITORY | tr "/" "-")
 EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
-# Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
-app="${INPUT_NAME:-pr-$PR_NUMBER-$REPO_OWNER-$REPO_NAME}"
+# Default the Fly app name to pr-{number}-{repo_name}
+app="${INPUT_NAME:-pr-$PR_NUMBER--$REPO_NAME}"
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,8 @@ if [ -n "$INPUT_SECRETS" ]; then
 fi
 
 echo "Contents of config $config file: " && cat "$config"
-flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate "$INPUT_EXTRA_DEPLOY_ARGS"
+deploy_cmd="flyctl deploy --config $config --app $app --region $region --image $image --strategy immediate $INPUT_EXTRA_DEPLOY_ARGS"
+eval $deploy_cmd
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -57,14 +57,14 @@ if [ -n "$INPUT_COUNT" ]; then
   flyctl scale --app "$app" count "$INPUT_COUNT"
 fi
 
-# Trigger the deploy of the new version.
-echo "Contents of config $config file: " && cat "$config"
-flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
-
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then
   flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
 fi
+
+# Trigger the deploy of the new version.
+echo "Contents of config $config file: " && cat "$config"
+flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 
 # Make some info available to the GitHub workflow.
 flyctl status --app "$app" --json >status.json

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ fi
 
 # Deploy the Fly app, creating it first if needed.
 if ! flyctl status --app "$app"; then
+  echo "Contents of config $config file: " && cat "$config"
   flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
 fi
 if [ -n "$INPUT_SECRETS" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,8 +47,13 @@ if [ -n "$INPUT_SECRETS" ]; then
 fi
 
 echo "Contents of config $config file: " && cat "$config"
-deploy_cmd="flyctl deploy --config $config --app $app --region $region --image $image --strategy immediate $INPUT_EXTRA_DEPLOY_ARGS"
-eval $deploy_cmd
+if [ -n "$INPUT_BUILD_SECRET" ]; then
+  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate --build-secret "$INPUT_BUILD_SECRET"
+else
+  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
+fi
+
+
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,12 +38,12 @@ fi
 if ! flyctl status --app "$app"; then
   flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
   if [ -n "$INPUT_SECRETS" ]; then
-    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app" --detach
+    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi
   flyctl deploy --app "$app" --region "$region" --image "$image" --strategy immediate
 elif [ "$INPUT_UPDATE" != "false" ]; then
   if [ -n "$INPUT_SECRETS" ]; then
-    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app" --detach
+    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi
   flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,9 +40,9 @@ if ! flyctl status --app "$app"; then
   if [ -n "$INPUT_SECRETS" ]; then
     echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi
-  flyctl deploy --app "$app" --region "$region" --image "$image" --region "$region" --strategy immediate
+  flyctl deploy --app "$app" --region "$region" --image "$image" --strategy immediate
 elif [ "$INPUT_UPDATE" != "false" ]; then
-  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --region "$region" --strategy immediate
+  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 fi
 
 # Attach postgres cluster to the app if specified.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,13 +47,7 @@ if [ -n "$INPUT_SECRETS" ]; then
 fi
 
 echo "Contents of config $config file: " && cat "$config"
-if [ -n "$INPUT_BUILD_SECRET" ]; then
-  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate --build-secret "$INPUT_BUILD_SECRET"
-else
-  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
-fi
-
-
+flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,8 @@ if [ -z "$PR_NUMBER" ]; then
   exit 1
 fi
 
-REPO_OWNER=$(jq -r .event.base.repo.owner /github/workflow/event.json)
-REPO_NAME=$(jq -r .event.base.repo.name /github/workflow/event.json)
+REPO_OWNER=$(GITHUB_REPOSITORY_OWNER)
+REPO_NAME=$(GITHUB_REPOSITORY)
 EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ if [ -n "$INPUT_SECRETS" ]; then
 fi
 
 echo "Contents of config $config file: " && cat "$config"
-flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate $INPUT_EXTRA_DEPLOY_ARGS
+flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate "$INPUT_EXTRA_DEPLOY_ARGS"
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,10 +38,13 @@ fi
 if ! flyctl status --app "$app"; then
   flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
   if [ -n "$INPUT_SECRETS" ]; then
-    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
+    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app" --detach
   fi
   flyctl deploy --app "$app" --region "$region" --image "$image" --strategy immediate
 elif [ "$INPUT_UPDATE" != "false" ]; then
+  if [ -n "$INPUT_SECRETS" ]; then
+    echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app" --detach
+  fi
   flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,8 @@ if [ -z "$PR_NUMBER" ]; then
   exit 1
 fi
 
-REPO_OWNER=$(GITHUB_REPOSITORY_OWNER)
-REPO_NAME=$(GITHUB_REPOSITORY)
+REPO_OWNER=$GITHUB_REPOSITORY_OWNER
+REPO_NAME=$GITHUB_REPOSITORY
 EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -39,12 +39,13 @@ if ! flyctl status --app "$app"; then
   # Backup the original config file since 'flyctl launch' messes up the [build.args] section
   cp "$config" "$config.bak"
   flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
+  # Restore the original config file
+  cp "$config.bak" "$config"
 fi
 if [ -n "$INPUT_SECRETS" ]; then
   echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
-# Restore the original config prior to deploy
-cp "$config.bak" "$config"
+
 echo "Contents of config $config file: " && cat "$config"
 flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,6 +7,8 @@ if [ -n "$INPUT_PATH" ]; then
   cd "$INPUT_PATH" || exit
 fi
 
+echo "Got workflow event: $(cat /github/workflow/event.json)"
+
 PR_NUMBER=$(jq -r .number /github/workflow/event.json)
 if [ -z "$PR_NUMBER" ]; then
   echo "This action only supports pull_request actions."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -54,6 +54,17 @@ if [ -n "$INPUT_POSTGRES" ]; then
   flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
 fi
 
+# Scale the VM
+if [ -n "$INPUT_VM" ]; then
+  flyctl scale --app "$app" vm "$INPUT_VM"
+fi
+if [ -n "$INPUT_MEMORY" ]; then
+  flyctl scale --app "$app" memory "$INPUT_MEMORY"
+fi
+if [ -n "$INPUT_COUNT" ]; then
+  flyctl scale --app "$app" count "$INPUT_COUNT"
+fi
+
 # Make some info available to the GitHub workflow.
 flyctl status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
@@ -61,3 +72,4 @@ appid=$(jq -r .ID status.json)
 echo "hostname=$hostname" >> $GITHUB_OUTPUT
 echo "url=https://$hostname" >> $GITHUB_OUTPUT
 echo "id=$appid" >> $GITHUB_OUTPUT
+echo "name=$app" >> $GITHUB_OUTPUT

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,15 +46,7 @@ if [ -n "$INPUT_SECRETS" ]; then
   echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
 fi
 
-echo "Contents of config $config file: " && cat "$config"
-flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
-
-# Attach postgres cluster to the app if specified.
-if [ -n "$INPUT_POSTGRES" ]; then
-  flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
-fi
-
-# Scale the VM
+# Scale the VM before the deploy.
 if [ -n "$INPUT_VM" ]; then
   flyctl scale --app "$app" vm "$INPUT_VM"
 fi
@@ -63,6 +55,15 @@ if [ -n "$INPUT_MEMORY" ]; then
 fi
 if [ -n "$INPUT_COUNT" ]; then
   flyctl scale --app "$app" count "$INPUT_COUNT"
+fi
+
+# Trigger the deploy of the new version.
+echo "Contents of config $config file: " && cat "$config"
+flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
+
+# Attach postgres cluster to the app if specified.
+if [ -n "$INPUT_POSTGRES" ]; then
+  flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
 fi
 
 # Make some info available to the GitHub workflow.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,6 +36,7 @@ fi
 
 # Deploy the Fly app, creating it first if needed.
 if ! flyctl status --app "$app"; then
+  echo "Contents of fly.toml file: " && cat fly.toml
   flyctl launch --no-deploy --copy-config --name "$app" --image "$image" --region "$region" --org "$org"
   if [ -n "$INPUT_SECRETS" ]; then
     echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
@@ -45,6 +46,7 @@ elif [ "$INPUT_UPDATE" != "false" ]; then
   if [ -n "$INPUT_SECRETS" ]; then
     echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
   fi
+  echo "Contents of fly.toml file: " && cat fly.toml
   flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,7 +47,7 @@ if [ -n "$INPUT_SECRETS" ]; then
 fi
 
 echo "Contents of config $config file: " && cat "$config"
-flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate
+flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate $INPUT_EXTRA_DEPLOY_ARGS
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then


### PR DESCRIPTION
1. Remove `${{ secrets.FIRST_SECRET }}` etc from action description since it was breaking the GHA start
2. Get org & repo from `GITHUB_REPOSITORY` env var present
3. Default `config` to `fly.toml` by default
4. Backup & restore `fly.toml` file before & after `flyctl launch` invocation to avoid it overwriting the `build.args`
5. Replace the deprecated usage of `::set-output` syntax with echo to `$GITHUB_OUTPUT`
6. Added VM scaling options