### PR TITLE
fix: adjust postgres attach command

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,7 +48,7 @@ fi
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then
-  flyctl postgres attach --postgres-app "$INPUT_POSTGRES" || true
+  flyctl postgres attach "$INPUT_POSTGRES" || true
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
Proposing a minor fix, it looks like this postgres attach syntax is incorrect, I'm seeing the following error when I try to attach to an existing postgres cluster.
![Screen Shot 2023-02-22 at 4 10 59 PM](https://user-images.githubusercontent.com/31930284/220792873-c521a113-ddee-417f-8434-ad9b0183cdf3.png)
