### PR TITLE
Update set-output commands

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -55,6 +55,6 @@ fi
 fly status --app "$app" --json >status.json
 hostname=$(jq -r .Hostname status.json)
 appid=$(jq -r .ID status.json)
-echo "::set-output name=hostname::$hostname"
-echo "::set-output name=url::https://$hostname"
-echo "::set-output name=id::$appid"
+echo "hostname=$hostname" >> $GITHUB_OUTPUT
+echo "url=https://$hostname" >> $GITHUB_OUTPUT
+echo "id=$appid" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Use of `save-state` and `set-output` commands in Github actions has been deprecated.

This PR updates the script to use the [environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files) method.

See more: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/