### PR TITLE
fix(secrets): remove string interpolation from description

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If you have an existing `fly.toml` in your repo, this action will copy it with a
 | `path`     | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
 | `postgres` | Optional name of an existing Postgres cluster to `flyctl postgres attach` to.                                                                                                                            |
 | `update`   | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
+| `secrets`  | Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`                                        |
 
 ## Required Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,4 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`
+    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=super-secret SECOND_SECRET=uber-secret`


### PR DESCRIPTION
The current description for the `secrets` field causes an error when the action is invoked:
```
Error: superfly/fly-pr-review-apps/main/action.yml (Line: 29, Col: 18): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.FIRST_SECRET
Error: Fail to load superfly/fly-pr-review-apps/main/action.yml
```

This change in description fixes this.

I'm also documenting that option in the readme.