### PR TITLE
Reassign db objects before dropping user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN apk --no-cache add git
 
 RUN which git
 
+RUN apk --no-cache --update add build-base
+
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,14 @@
 FROM alpine
 
+RUN apk update && apk upgrade
+
 RUN apk add --no-cache curl jq
 
 RUN curl -L https://fly.io/install.sh | FLYCTL_INSTALL=/usr/local sh
+
+RUN apk --no-cache add git
+
+RUN which git
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/action.yml
+++ b/action.yml
@@ -26,4 +26,5 @@ inputs:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true
   secrets:
-    description: Secrets to be set on the app. Separate multiple secrets with a space, i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`
+    description: Secrets to be set on the app. Separate multiple secrets with a space,
+    # i.e., `FIRST_SECRET=${{ secrets.FIRST_SECRET }} SECOND_SECRET=${{ secrets.SECOND_SECRET }}`

--- a/action.yml
+++ b/action.yml
@@ -21,7 +21,9 @@ inputs:
   path:
     description: path to a directory containing a fly.toml to clone
   postgres:
-    description: Optionally attach the app to a pre-existing Postgres cluster on Fly
+    description: Postgres cluster on Fly to attach the preview to
+  database:
+    description: dev database for the application
   update:
     description: Whether new commits to the PR should re-deploy the Fly app
     default: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,6 +78,9 @@ if ! echo "$secrets" | grep -q "DATABASE_URL"; then
 
     # Execute DROP USER command using flyctl postgres connect
     eval "flyctl postgres connect -a "$INPUT_POSTGRES" <<EOF
+    \c $database;
+    REASSIGN OWNED BY $postgres_user TO postgres;
+    DROP OWNED BY $postgres_user;
     DROP USER $postgres_user;
     \q
     EOF"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ if ! flyctl status --app "$app"; then
   mix local.hex --force
 
   # Launch new app
-  flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --remote-only
+  flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --remote-only --ha=false
 
   # Add app host to env secrets
   flyctl secrets set --app "$app" PHX_HOST="$app".fly.dev

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -46,6 +46,9 @@ if ! flyctl status --app "$app"; then
   # Launch new app
   flyctl launch --no-deploy --copy-config --name "$app" --region "$region" --org "$org" --remote-only
 
+  # Add app host to env secrets
+  flyctl secrets set --app "$app" PHX_HOST="$app".fly.dev
+
   if [ -n "$INPUT_POSTGRES" ]; then
     # Attach app to postgres database
     flyctl postgres attach --app "$app" "$INPUT_POSTGRES" || true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,6 +31,19 @@ fi
 
 # PR was closed - remove the Fly app if one exists and exit.
 if [ "$EVENT_TYPE" = "closed" ]; then
+  if [ -n "$INPUT_POSTGRES" ]; then
+    apk add expect
+
+    # Detach app from postgres cluster and database.
+    expect -c "
+      spawn flyctl postgres detach "$INPUT_POSTGRES" --app "$app"
+      expect {Select the attachment that you would like to detach*}
+      send -- \"\r\"
+      expect eof
+    "
+  fi
+
+  # Destroy the Fly app
   flyctl apps destroy "$app" -y || true
   exit 0
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,6 +22,7 @@ region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
 config="${INPUT_CONFIG:-fly.toml}"
+database="${INPUT_DATABASE:-$app}"
 
 if ! echo "$app" | grep "$PR_NUMBER"; then
   echo "For safety, this action requires the app's name to contain the PR number."
@@ -50,8 +51,8 @@ if ! flyctl status --app "$app"; then
   flyctl secrets set --app "$app" PHX_HOST="$app".fly.dev
 
   if [ -n "$INPUT_POSTGRES" ]; then
-    # Attach app to postgres database
-    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" || true
+    # Attach app to postgres cluster and database.
+    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" --database-name "$database" || true
   fi
 
   # Restore the original config file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ if ! flyctl status --app "$app"; then
 
   if [ -n "$INPUT_POSTGRES" ]; then
     # Attach app to postgres cluster and database.
-    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" --database-name "$database" || true
+    flyctl postgres attach --app "$app" "$INPUT_POSTGRES" --database-name "$database" --yes || true
   fi
 
   # Restore the original config file


### PR DESCRIPTION
In the current review app deployment implementation, before launching a pull request app, any user with the PR app name in the PostgreSQL cluster is first dropped, but what if a user cannot be dropped because it owns some database objects (such as tables, views, functions, etc.)? In this case, these objects need to be reassigned to a reliable user like `postgres` before dropping the user.

Closes #19 