### PR TITLE
Fixed setting config.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,7 +21,7 @@ app="${INPUT_NAME:-pr-$PR_NUMBER-$GITHUB_REPOSITORY_OWNER-$GITHUB_REPOSITORY_NAM
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"
-config="${$INPUT_CONFIG:-fly.toml}"
+config="${INPUT_CONFIG:-fly.toml}"
 
 if ! echo "$app" | grep "$PR_NUMBER"; then
   echo "For safety, this action requires the app's name to contain the PR number."


### PR DESCRIPTION
Regression in cf8536b2494682533f0cb331caaea1e7972bb0cc.

It crashes with:
```
/entrypoint.sh: line 25: syntax error: bad substitution
```