### PR TITLE
Replaced underscores with hyphens in app names.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,8 @@ EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 
 # Default the Fly app name to pr-{number}-{repo_owner}-{repo_name}
 app="${INPUT_NAME:-pr-$PR_NUMBER-$GITHUB_REPOSITORY_OWNER-$GITHUB_REPOSITORY_NAME}"
+# Change underscores to hyphens.
+app="${app//_/-}"
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"


### PR DESCRIPTION
It seems that underscore is the only illegal character that we need to worry about:
```
+ flyctl launch --no-deploy --copy-config --name pr-1-felixxm-fly_pr_preview_example --image  --region waw --org personal
An existing fly.toml file was found for app fly-pr-preview-example
Scanning source code
Detected a Django app
The following problems must be fixed in the Launch UI:
 * app name must consist of only lowercase letters, numbers, and dashes
```