### PR TITLE
Attached PostgreSQL cluster to the PR app.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ fi
 
 # Attach postgres cluster to the app if specified.
 if [ -n "$INPUT_POSTGRES" ]; then
-  flyctl postgres attach "$INPUT_POSTGRES" || true
+  flyctl postgres attach "$INPUT_POSTGRES" --app "$app" || true
 fi
 
 # Trigger the deploy of the new version.


### PR DESCRIPTION
We shouldn't attach PostgreSQL cluster to the main app:
```
Checking for existing attachments
Error: consumer app "fly-pr-preview-example" already contains a secret named DATABASE_URL
```