### PR TITLE
fix: flyctl deploy flag from region to regions

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,9 +56,9 @@ fi
 # Trigger the deploy of the new version.
 echo "Contents of config $config file: " && cat "$config"
 if [ -n "$INPUT_VM" ]; then
-  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE"
 else
-  flyctl deploy --config "$config" --app "$app" --region "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY"
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
`flyctl` [v0.2.47](https://github.com/superfly/flyctl/releases/tag/v0.2.47) [[PR]](https://github.com/superfly/flyctl/pull/3514) silently broke everyones CI/CDs. It broke my review apps. This fixes that change.

This really needs to go out ASAP as it breaks ALL review apps until it's fixed. I'm changing mine to manually run this code until this is merged in and released.