### PR TITLE
Cast app name to lower case

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,8 @@ EVENT_TYPE=$(jq -r .action /github/workflow/event.json)
 app="${INPUT_NAME:-pr-$PR_NUMBER-$GITHUB_REPOSITORY_OWNER-$GITHUB_REPOSITORY_NAME}"
 # Change underscores to hyphens.
 app="${app//_/-}"
+# Change to lower case
+app=$(echo "$app" | tr '[:upper:]' '[:lower:]')
 region="${INPUT_REGION:-${FLY_REGION:-iad}}"
 org="${INPUT_ORG:-${FLY_ORG:-personal}}"
 image="$INPUT_IMAGE"


### PR DESCRIPTION
Preview workflow fails if app name is not lower case but GitHub repository owners can be upper case.  By changing app name to be all lower case it prevents this error from arising.