### PR TITLE
Add deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ If you have an existing `fly.toml` in your repo, this action will copy it with a
 | `cpukind`  | Set app VM CPU kind - shared or performance. Default shared.                                                                                                                                             |
 | `memory`   | Set app VM memory in megabytes. Default 256.                                                                                                                                                             |
 | `ha`       | Create spare machines that increases app availability. Default `false`.                                                                                                                                  |
-| `launch_options`       | Attaches additional options to fly at app creation if specified                                                                                                                                  |
+| `launch_options`       | Attaches additional options to the fly launch command if specified                                                                                                                              |
+| `deploy_options`       | Attaches additional options to the fly deploy command if specified                                                                                                                                  |
 
 ## Required Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -40,3 +40,5 @@ inputs:
     default: false
   launch_options:
     description: Additional options to pass to the Fly launch command at creation
+  deploy_option:
+    description: Additional options to pass to the Fly deploy command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -56,9 +56,9 @@ fi
 # Trigger the deploy of the new version.
 echo "Contents of config $config file: " && cat "$config"
 if [ -n "$INPUT_VM" ]; then
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-size "$INPUT_VMSIZE" $INPUT_DEPLOY_OPTIONS
 else
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY" $INPUT_DEPLOY_OPTIONS
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
# What does this PR do?

Adds a `deploy_options` input to the github action which is appended to the `fly deploy ...` command allowing the user of the action to configure anything the `fly deploy` command supports.

# Why?

The main use case I had for this was specifying the`build-arg` option. If preferred, we could add that in? Although I think this will solve more use cases and can help if/when fly adds more options to the deploy command.

# More Info

I updated the doc on launch_options to be more specific as well. 

Open for any feedback/adjustments