### PR TITLE
Add deploy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you have an existing `fly.toml` in your repo, this action will copy it with a
 | `memory`   | Set app VM memory in megabytes. Default 256.                                                                                                                                                             |
 | `ha`       | Create spare machines that increases app availability. Default `false`.                                                                                                                                  |
 | `launch_options`       | Attaches additional options to fly at app creation if specified                                                                                                                                  |
+| `deploy_options` | Attaches additional options to the fly deploy command if specified |
 
 ## Required Secrets
 

--- a/action.yml
+++ b/action.yml
@@ -44,3 +44,5 @@ inputs:
     default: false
   launch_options:
     description: Additional options to pass to the Fly launch command at creation
+  deploy_options:
+    description: Additional options to pass to the Fly deploy command

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -71,9 +71,9 @@ fi
 # Trigger the deploy of the new version.
 echo "Contents of config $config file: " && cat "$config"
 if [ -n "$INPUT_VM" ]; then
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA ${build_args} ${build_secrets} --vm-size "$INPUT_VMSIZE"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA ${build_args} ${build_secrets} --vm-size "$INPUT_VMSIZE" $INPUT_DEPLOY_OPTIONS
 else
-  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA ${build_args} ${build_secrets} --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY"
+  flyctl deploy --config "$config" --app "$app" --regions "$region" --image "$image" --strategy immediate --ha=$INPUT_HA ${build_args} ${build_secrets} --vm-cpu-kind "$INPUT_CPUKIND" --vm-cpus $INPUT_CPU --vm-memory "$INPUT_MEMORY" $INPUT_DEPLOY_OPTIONS
 fi
 
 # Make some info available to the GitHub workflow.


### PR DESCRIPTION
Same changes as https://github.com/superfly/fly-pr-review-apps/pull/70 but this one fixes the typo and hopefully it does not get abandoned

Without this command we entirely depend on depot for building images, which makes the CI setup very prone to outages