### PR TITLE
feat: only allow secrets to be separated by a newline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you have an existing `fly.toml` in your repo, this action will copy it with a
 | `path`     | Path to run the `flyctl` commands from. Useful if you have an existing `fly.toml` in a subdirectory.                                                                                                     |
 | `postgres` | Optional name of an existing Postgres cluster to `flyctl postgres attach` to.                                                                                                                            |
 | `update`   | Whether or not to update this Fly app when the PR is updated. Default `true`.                                                                                                                            |
-| `secrets`  | Secrets to be set on the app at runtime. Separate multiple secrets with a space                                                                                                                                     |
+| `secrets`  | Secrets to be set on the app at runtime. Separate multiple secrets with a new line                                                                                                                                     |
 | `build_args` | Optional Docker --build-arg |
 | `build_secrets` | Optional Docker --build-secret |
 | `vmsize`   | Set app VM to a named size, eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x etc. Takes precedence over cpu, cpu kind, and memory inputs.                                                           |

--- a/action.yml
+++ b/action.yml
@@ -27,7 +27,7 @@ inputs:
   postgres:
     description: Optionally attach the app to a pre-existing Postgres cluster on Fly
   secrets:
-    description: Secrets to be set on the app at runtime. Separate multiple secrets with a space
+    description: Secrets to be set on the app at runtime. Separate multiple secrets with a new line
   vmsize:
     description: Set app VM to a named size, eg. shared-cpu-1x, dedicated-cpu-1x, dedicated-cpu-2x etc. Takes precedence over cpu, cpu kind, and memory inputs.
   cpu:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -60,7 +60,7 @@ if ! flyctl status --app "$app"; then
 fi
 
 if [ -n "$INPUT_SECRETS" ]; then
-  echo $INPUT_SECRETS | tr " " "\n" | flyctl secrets import --app "$app"
+  echo $INPUT_SECRETS | flyctl secrets import --app "$app"
 fi
 
 # Attach postgres cluster to the app if specified.


### PR DESCRIPTION
BREAKING CHANGE: having multiple secrets separated by spaces is now invalid syntax
---

Having a secret containing a space " " breaks this action. In my opinion, it's simpler to just require secrets to be split be on their own line, having multiple secrets on the same line is also a little hard on the eyes. 

I've smoke tested this on the offending repo that it was breaking for me on, pointing the action to my fork and putting secrets on new lines fixed the issue, the deployment succeeded with correct secrets.

This would be a breaking change for existing workflows, so will require at the very least a minor bump.