### PR TITLE
feat: support issue_comment events for comment-triggered deploys

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,9 +7,10 @@ if [ -n "$INPUT_PATH" ]; then
   cd "$INPUT_PATH" || exit
 fi
 
-PR_NUMBER=$(jq -r .number /github/workflow/event.json)
-if [ -z "$PR_NUMBER" ]; then
-  echo "This action only supports pull_request actions."
+# Support both pull_request (.number) and issue_comment (.issue.number) events
+PR_NUMBER=$(jq -r '.number // .issue.number' /github/workflow/event.json)
+if [ -z "$PR_NUMBER" ] || [ "$PR_NUMBER" = "null" ]; then
+  echo "Could not determine PR number. This action supports pull_request and issue_comment events."
   exit 1
 fi
 


### PR DESCRIPTION
## Problem

When using `issue_comment` events to trigger preview deploys (e.g., via `/preview` comments), the action fails because it reads the PR number from `.number` in the event payload, which only exists on `pull_request` events. For `issue_comment` events, the PR number is at `.issue.number`.

## Fix

Falls back to `.issue.number` when `.number` is not present:

```sh
# Before
PR_NUMBER=$(jq -r .number /github/workflow/event.json)

# After
PR_NUMBER=$(jq -r '.number // .issue.number' /github/workflow/event.json)
```

Fully backwards compatible — `pull_request` events still use `.number` as before. The `//` operator only kicks in when `.number` is `null`.

## Use case

```yaml
# Trigger preview deploy via /preview comment
on:
  issue_comment:
    types: [created]

jobs:
  preview:
    if: contains(github.event.comment.body, '/preview')
    steps:
      - uses: superfly/fly-pr-review-apps@main
        with:
          name: my-app-pr-${{ github.event.issue.number }}
```